### PR TITLE
Fixed a typo when creating the virtual environment. (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ cd plant-tracker
 Create a virtual environment to install dependencies in and activate it:
 
 ```sh
-$ python -m venv /venv/
+$ python -m venv ./venv/
 $ venv/Scripts/activate.bat
 ```
 


### PR DESCRIPTION
I've added a period "." before the virtual environment directory to avoid trying to create it in the root directory.